### PR TITLE
Hotfixes/delete

### DIFF
--- a/include/lab2_sync_types.h
+++ b/include/lab2_sync_types.h
@@ -41,6 +41,7 @@ typedef struct lab2_node {
  *  struct lab2_node *root  : root node of bst.
  */
 typedef struct lab2_tree {
+    pthread_mutex_t mutex;
     struct lab2_node *root;
 } lab2_tree;
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -432,5 +432,6 @@ void lab2_tree_delete(lab2_tree *tree) { // 트리를 초기화
  */
 void lab2_node_delete(lab2_node *node) { // 삭제한 노드의 메모리 할당 제거
     free(node);
+    node = NULL;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -91,7 +91,7 @@ int lab2_node_insert(lab2_tree *tree, lab2_node *new_node) {
             }
         }
     }
-    return SUCCESS;
+    return LAB2_SUCCESS;
 }
 
 /* 
@@ -104,6 +104,31 @@ int lab2_node_insert(lab2_tree *tree, lab2_node *new_node) {
  */
 int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
       // You need to implement lab2_node_insert_fg function.
+      lab2_node *temp = tree -> root;
+    if(temp == NULL) {
+        tree -> root = new_node;
+    } else {
+        while(1) {
+            if(temp -> key < new_node -> key) {
+                pthread_mutex_lock(&temp -> mutex);
+                if(!(temp -> right)) {
+                    temp -> right =  new_node;
+                    break;
+                }
+                temp = temp -> right;
+                pthread_mutex_unlock(&temp -> mutex);
+            } else if(temp -> key > new_node -> key) {
+                pthread_mutex_lock(&temp -> mutex);
+                if(!(temp -> left)) {
+                    temp -> left = new_node;
+                    break;
+                }
+                temp = temp -> left;
+                pthread_mutex_unlock(&temp -> mutex);
+            }
+        }
+    }
+    return LAB2_SUCCESS;
 }
 
 /* 
@@ -116,6 +141,7 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
  */
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert_cg function.
+
 }
 
 /* 
@@ -130,7 +156,7 @@ int lab2_node_remove(lab2_tree *tree, int key) {
     lab2_node *temp = tree -> root;
     lab2_node *parent, *child = NULL;
     if(temp == NULL) {
-        return SUCCESS;
+        return LAB2_SUCCESS;
     }
     while(temp -> key != key) {
         if(temp -> key < key) {
@@ -149,7 +175,7 @@ int lab2_node_remove(lab2_tree *tree, int key) {
             parent -> right == NULL;
         }
         lab2_node_delete(temp);
-        return SUCCESS;
+        return LAB2_SUCCESS;
     }
     if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
         if(temp -> left) {
@@ -163,7 +189,7 @@ int lab2_node_remove(lab2_tree *tree, int key) {
             parent -> right = child;
         }
         lab2_node_delete(temp);
-        return SUCCESS;
+        return LAB2_SUCCESS;
     }
     if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
         lab2_node *temp2 = temp -> right;
@@ -176,7 +202,7 @@ int lab2_node_remove(lab2_tree *tree, int key) {
             parent->left = temp2->right;
         }
         lab2_node_delete(temp2);
-        return SUCCESS;
+        return LAB2_SUCCESS;
     }
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -110,34 +110,34 @@ int lab2_node_insert(lab2_tree *tree, lab2_node *new_node) {
  */
 int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
       // You need to implement lab2_node_insert_fg function.
-    //   lab2_node *temp = tree -> root;
-    // if(temp == NULL) {
-    //     tree -> root = new_node;
-    // } else {
-    //     while(1) {
-    //         if(temp -> key < new_node -> key) {
-    //             if(!(temp -> right)) {
-    //                 pthread_mutex_lock(&temp -> mutex);
-    //                 temp -> right =  new_node;
-    //                 pthread_mutex_unlock(&temp -> mutex);
-    //                 break;
-    //             }
-    //             pthread_mutex_lock(&temp -> mutex);
-    //             temp = temp -> right;
-    //             pthread_mutex_unlock(&temp -> mutex);
-    //         } else if(temp -> key > new_node -> key) {
-    //             if(!(temp -> left)) {
-    //                 pthread_mutex_lock(&temp -> mutex);
-    //                 temp -> left = new_node;
-    //                 pthread_mutex_unlock(&temp -> mutex);
-    //                 break;
-    //             }
-    //             pthread_mutex_lock(&temp -> mutex);
-    //             temp = temp -> left;
-    //             pthread_mutex_unlock(&temp -> mutex);
-    //         }
-    //     }
-    // }
+      lab2_node *temp = tree -> root;
+    if(temp == NULL) {
+        tree -> root = new_node;
+    } else {
+        while(1) {
+            if(temp -> key < new_node -> key) {
+                if(!(temp -> right)) {
+                    pthread_mutex_lock(&temp -> mutex);
+                    temp -> right =  new_node;
+                    pthread_mutex_unlock(&temp -> mutex);
+                    break;
+                }
+                pthread_mutex_lock(&temp -> mutex);
+                temp = temp -> right;
+                pthread_mutex_unlock(&temp -> mutex);
+            } else if(temp -> key > new_node -> key) {
+                if(!(temp -> left)) {
+                    pthread_mutex_lock(&temp -> mutex);
+                    temp -> left = new_node;
+                    pthread_mutex_unlock(&temp -> mutex);
+                    break;
+                }
+                pthread_mutex_lock(&temp -> mutex);
+                temp = temp -> left;
+                pthread_mutex_unlock(&temp -> mutex);
+            }
+        }
+    }
     return LAB2_SUCCESS;
 }
 
@@ -151,29 +151,30 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
  */
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert_cg function.
-    // lab2_node *temp = tree -> root;
-    // if(temp == NULL) {
-    //     tree -> root = new_node;
-    //     return LAB2_SUCCESS;
-    // } else {
-    //     pthread_mutex_lock(&temp->mutex); // lock 걸어줌
-    //     while(1) {
-    //         if(temp -> key < new_node -> key) {
-    //             if(!(temp -> right)) {
-    //                 temp -> right =  new_node;
-    //                 break;
-    //             }
-    //             temp = temp -> right;
-    //         } else if(temp -> key > new_node -> key) {
-    //             if(!(temp -> left)) {
-    //                 temp -> left = new_node;
-    //                 break;
-    //             }
-    //             temp = temp -> left;
-    //         }
-    //     }
-    //     pthread_mutex_unlock(&temp->mutex); // lock 해제
-    // }
+    pthread_mutex_lock(&(tree -> root) -> mutex); // lock 걸어줌
+    lab2_node *temp = tree -> root;
+    if(temp == NULL) {
+        tree -> root = new_node;
+        pthread_mutex_unlock(&temp->mutex); // lock 해제
+        return LAB2_SUCCESS;
+    } else {
+        while(1) {
+            if(temp -> key < new_node -> key) {
+                if(!(temp -> right)) {
+                    temp -> right =  new_node;
+                    break;
+                }
+                temp = temp -> right;
+            } else if(temp -> key > new_node -> key) {
+                if(!(temp -> left)) {
+                    temp -> left = new_node;
+                    break;
+                }
+                temp = temp -> left;
+            }
+        }
+    }
+    pthread_mutex_unlock(&temp->mutex); // lock 해제
     return LAB2_SUCCESS;
 }
 
@@ -248,87 +249,68 @@ int lab2_node_remove(lab2_tree *tree, int key) {
  */
 int lab2_node_remove_fg(lab2_tree *tree, int key) {
     // You need to implement lab2_node_remove_fg function.
-    // lab2_node *temp = tree -> root;
-    // lab2_node *parent, *child = NULL;
-    // int result;
-    // if(temp == NULL) {
-    //     return LAB2_SUCCESS;
-    // }
-    // while(temp -> key != key) {
-    //     if(temp -> key < key) {
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         parent = temp;
-    //         temp = temp -> right;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     } else {
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         parent = temp;
-    //         temp = temp -> left;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     }
-        
-    // }
-    // if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
-    //     if(parent -> left == temp) {
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         parent -> left = NULL;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     }
-    //     if(parent -> right == temp) {
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         parent -> right = NULL;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     }
-    //     pthread_mutex_lock(&temp -> mutex);
-    //     lab2_node_delete(temp);
-    //     pthread_mutex_unlock(&temp -> mutex);
-    //     return LAB2_SUCCESS;
-    // }
-    // if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
-    //     if(temp -> left) {
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         child = temp -> left;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     } else {
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         child = temp -> right;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     }
-    //     if(parent -> left == temp) {
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         parent -> left = child;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     } else {
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         parent -> right = child;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     }
-    //     pthread_mutex_lock(&temp -> mutex);
-    //     lab2_node_delete(temp);
-    //     pthread_mutex_unlock(&temp -> mutex);
-    //     return LAB2_SUCCESS;
-    // }
-    // if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
-    //     lab2_node *temp2 = temp -> right;
-    //     while(temp2->left != NULL){
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         parent = temp2;
-    //         temp2 = temp2->left;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     }
-    //     pthread_mutex_lock(&temp -> mutex);
-    //     temp->key = temp2->key;
-    //     pthread_mutex_unlock(&temp -> mutex);
-    //     if(temp2->right != NULL){
-    //         pthread_mutex_lock(&temp -> mutex);
-    //         parent->left = temp2->right;
-    //         pthread_mutex_unlock(&temp -> mutex);
-    //     }
-    //     pthread_mutex_lock(&temp -> mutex);
-    //     lab2_node_delete(temp2);
-    //     pthread_mutex_unlock(&temp -> mutex);
-    //     return LAB2_SUCCESS;
-    // }
+    lab2_node *temp = tree -> root;
+    lab2_node *parent = NULL , *child, *succ, *succ_p;
+    while(temp -> key != key && temp != NULL) {
+        pthread_mutex_lock(&temp->mutex);
+        parent = temp;
+        temp = (key < temp -> key) ? temp->left : temp->right;
+        pthread_mutex_unlock(&temp->mutex);
+    }
+    if(temp == NULL) {
+        return LAB2_SUCCESS;
+    }
+    if((temp -> left == NULL) && (temp -> right == NULL)) { // 아래에 자식 노드가 없을 경우
+        pthread_mutex_lock(&temp->mutex);
+        if (parent != NULL)
+        {
+            if(parent -> left == temp) {
+                parent -> left = NULL;
+            } else {
+                parent -> right = NULL;
+            }
+        } else {
+            tree -> root = NULL;
+        }
+        pthread_mutex_unlock(&temp->mutex);
+    } else if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+        pthread_mutex_lock(&temp->mutex);
+        child = (temp -> left != NULL) ? temp -> left : temp -> right;
+        if(parent != NULL) {
+            if(parent -> left == temp) {
+                parent -> left = child;
+            } else {
+                parent -> right = child;
+            }
+        } else {
+            tree -> root = child;
+        }
+        pthread_mutex_unlock(&temp->mutex);
+    } else {
+          // 아래에 2개의 자식 노드가 있을 경우
+        pthread_mutex_lock(&temp->mutex);
+        succ_p = temp;
+        succ = temp -> right;
+        pthread_mutex_unlock(&temp->mutex);
+        while(succ -> left != NULL) {
+            pthread_mutex_lock(&temp->mutex);
+            succ_p = succ;
+            succ = succ -> left;
+            pthread_mutex_unlock(&temp->mutex);
+        }
+        pthread_mutex_lock(&temp->mutex);
+        if(succ_p -> left == succ) {
+            succ_p -> left = succ -> right;
+        } else {
+            succ_p -> right = succ -> right;
+        }
+        temp -> key = succ -> key;
+        temp = succ;
+        pthread_mutex_unlock(&temp->mutex);
+    }
+    pthread_mutex_lock(&temp->mutex);
+    lab2_node_delete(temp);
+    pthread_mutex_unlock(&temp->mutex);
     return LAB2_SUCCESS;
 }
 
@@ -342,62 +324,58 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
  *  @return                 : status (success or fail)
  */
 int lab2_node_remove_cg(lab2_tree *tree, int key) {
-    // lab2_node *temp = tree -> root;
-    // lab2_node *parent, *child = NULL;
-    // if(temp == NULL) {
-    //     return LAB2_SUCCESS;
-    // }
-    // pthread_mutex_lock(&temp->mutex);
-    // while(temp -> key != key) {
-    //     if(temp -> key < key) {
-    //         parent = temp;
-    //         temp = temp -> right;
-    //     } else {
-    //         parent = temp;
-    //         temp = temp -> left;
-    //     }
-    // }
-    // if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
-    //     if(parent -> left == temp) {
-    //         parent -> left = NULL;
-    //     }
-    //     if(parent -> right == temp) {
-    //         parent -> right = NULL;
-    //     }
-    //     lab2_node_delete(temp);
-    //     pthread_mutex_unlock(&temp->mutex);
-    //     return LAB2_SUCCESS;
-    // }
-    // if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
-    //     if(temp -> left) {
-    //         child = temp -> left;
-    //     } else {
-    //         child = temp -> right;
-    //     }
-    //     if(parent -> left == temp) {
-    //         parent -> left = child;
-    //     } else {
-    //         parent -> right = child;
-    //     }
-    //     lab2_node_delete(temp);
-    //     pthread_mutex_unlock(&temp->mutex);
-    //     return LAB2_SUCCESS;
-    // }
-    // if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
-    //     lab2_node *temp2 = temp -> right;
-    //     while(temp2->left != NULL){
-    //         parent = temp2;
-    //         temp2 = temp2->left;
-    //     }
-    //     temp->key = temp2->key;
-    //     if(temp2->right != NULL){
-    //         parent->left = temp2->right;
-    //     }
-    //     lab2_node_delete(temp2);
-    //     pthread_mutex_unlock(&temp->mutex);
-    //     return LAB2_SUCCESS;
-    // }
-    // pthread_mutex_lock(&temp->mutex);
+    pthread_mutex_lock(&(tree -> root) -> mutex);
+    lab2_node *temp = tree -> root;
+    lab2_node *parent = NULL , *child, *succ, *succ_p;
+    while(temp -> key != key && temp != NULL) {
+        parent = temp;
+        temp = (key < temp -> key) ? temp->left : temp->right;
+    }
+    if(temp == NULL) {
+        pthread_mutex_unlock(&(tree -> root) -> mutex);
+        return LAB2_SUCCESS;
+    }
+    if((temp -> left == NULL) && (temp -> right == NULL)) { // 아래에 자식 노드가 없을 경우
+        if (parent != NULL)
+        {
+            if(parent -> left == temp) {
+                parent -> left = NULL;
+            } else {
+                parent -> right = NULL;
+            }
+        } else {
+            tree -> root = NULL;
+        }
+        
+    } else if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+        child = (temp -> left != NULL) ? temp -> left : temp -> right;
+        if(parent != NULL) {
+            if(parent -> left == temp) {
+                parent -> left = child;
+            } else {
+                parent -> right = child;
+            }
+        } else {
+            tree -> root = child;
+        }
+    } else {
+          // 아래에 2개의 자식 노드가 있을 경우
+        succ_p = temp;
+        succ = temp -> right;
+        while(succ -> left != NULL) {
+            succ_p = succ;
+            succ = succ -> left;
+        }
+        if(succ_p -> left == succ) {
+            succ_p -> left = succ -> right;
+        } else {
+            succ_p -> right = succ -> right;
+        }
+        temp -> key = succ -> key;
+        temp = succ;
+    }
+    lab2_node_delete(temp);
+    pthread_mutex_unlock(&(tree -> root) -> mutex);
     return LAB2_SUCCESS;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -100,7 +100,32 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
  */
 lab2_node *lab2_node_remove(lab2_tree *tree, int key) {
     // You need to implement lab2_node_remove function.
-    
+    if (tree == NULL) {
+        return tree;
+    }
+    if (key < tree->key) {
+        tree->left = lab2_node_remove(tree->left, key);
+    } else if (key > tree->key) {
+        tree->right = lab2_node_remove(tree->right, key);
+    } else {
+        if (tree->left == NULL) { // 왼쪽 자식이 없을때
+            Node *temp = tree->right;
+            tree = NULL;
+            return temp; // 오른쪽 자식을 리턴(삭제할 노드의 부모노드와 연결)
+        } else if (tree->right == NULL) { // 오른쪽 자식이 없을때
+            Node *temp = tree->left;
+            tree = NULL;
+            return temp; // 왼쪽 자식을 리턴
+        }
+        // 왼쪽과 오른쪽 자식이 모두 있는 경우
+        lab2_node *temp = tree->right;
+        while (temp->left != NULL) {
+            temp = temp->left; // 오른쪽 자식의 가장 작은 값
+        }
+        tree->key = temp->key; // 삭제할 노드의 값을 오른쪽 자식의 가장 작은 값으로 바꿈
+        tree->right = lab2_node_remove(tree->right, temp->key); // 바꾼 값을 가진 노드를 찾아서 지움
+    }
+    return tree;
 }
 
 /* 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -34,6 +34,7 @@ void inorder(lab2_node *node) {
 }
 int lab2_node_print_inorder(lab2_tree * tree) {
     inorder(tree -> root);
+    return LAB2_SUCCESS;
 }
 
 /*
@@ -205,7 +206,7 @@ int lab2_node_remove(lab2_tree *tree, int key) {
             parent -> left = NULL;
         }
         if(parent -> right == temp) {
-            parent -> right == NULL;
+            parent -> right = NULL;
         }
         lab2_node_delete(temp);
         return LAB2_SUCCESS;
@@ -237,6 +238,7 @@ int lab2_node_remove(lab2_tree *tree, int key) {
         lab2_node_delete(temp2);
         return LAB2_SUCCESS;
     }
+    return LAB2_SUCCESS;
 }
 
 /* 
@@ -277,7 +279,7 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
         }
         if(parent -> right == temp) {
             pthread_mutex_lock(&temp -> mutex);
-            parent -> right == NULL;
+            parent -> right = NULL;
             pthread_mutex_unlock(&temp -> mutex);
         }
         pthread_mutex_lock(&temp -> mutex);
@@ -330,7 +332,7 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
         pthread_mutex_unlock(&temp -> mutex);
         return LAB2_SUCCESS;
     }
-
+    return LAB2_SUCCESS;
 }
 
 
@@ -346,7 +348,7 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
     lab2_node *temp = tree -> root;
     lab2_node *parent, *child = NULL;
     if(temp == NULL) {
-        return LAB2_SUCCESS
+        return LAB2_SUCCESS;
     }
     pthread_mutex_lock(&temp->mutex);
     while(temp -> key != key) {
@@ -363,11 +365,11 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
             parent -> left = NULL;
         }
         if(parent -> right == temp) {
-            parent -> right == NULL;
+            parent -> right = NULL;
         }
         lab2_node_delete(temp);
         pthread_mutex_unlock(&temp->mutex);
-        return LAB2_SUCCESS
+        return LAB2_SUCCESS;
     }
     if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
         if(temp -> left) {
@@ -382,7 +384,7 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
         }
         lab2_node_delete(temp);
         pthread_mutex_unlock(&temp->mutex);
-        return LAB2_SUCCESS
+        return LAB2_SUCCESS;
     }
     if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
         lab2_node *temp2 = temp -> right;
@@ -399,6 +401,7 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
         return LAB2_SUCCESS;
     }
     pthread_mutex_lock(&temp->mutex);
+    return LAB2_SUCCESS;
 }
 
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -63,7 +63,26 @@ lab2_node * lab2_node_create(int key) {
  */
 int lab2_node_insert(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert function.
-
+    lab2_node * comp = this -> root; // 비교 노드를 설정
+    while(true)
+    {
+        if(comp -> data < new_node -> data) //루트의 key값보다 새로운 노드의 키값이 더 클때
+        {
+            if(comp -> right == NULL) // 루트의 오른쪽 자식이 없을 때
+            {
+                comp -> right = new_node;
+                break;
+            } else comp = comp -> right; // 비교 노드를 오른쪽 자식 노드로 변경
+            else
+            {
+                {
+                if(comp -> left == NULL)
+                    comp -> left = new_node;
+                    break;
+                } else comp = comp -> left;
+            }
+        }
+    }
 }
 
 /* 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -259,10 +259,12 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
     lab2_node *temp = tree -> root;
     lab2_node *parent = NULL , *child, *succ, *succ_p;
     
+    pthread_mutex_lock(&tree -> mutex);
     while(temp != NULL && temp -> key != key) {
         parent = temp;
         temp = (key < temp -> key) ? temp->left : temp->right;
     }
+    pthread_mutex_unlock(&tree -> mutex);
     
     if(temp == NULL) {
         return LAB2_SUCCESS;

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -39,6 +39,10 @@ int lab2_node_print_inorder(lab2_tree *tree) {
  */
 lab2_tree *lab2_tree_create() {
     // You need to implement lab2_tree_create function.
+    // mutex 함수 추가필요.
+    lab2_tree *tree = (lab2_tree *) malloc(sizeof(lab2_tree));
+    tree -> root = NULL;
+    return tree;
 }
 
 /*
@@ -51,6 +55,12 @@ lab2_tree *lab2_tree_create() {
  */
 lab2_node * lab2_node_create(int key) {
     // You need to implement lab2_node_create function.
+    // mutex 함수 추가 필요.
+    lab2_node *node = (lab2_node *) malloc(sizeof(lab2_node));
+    node -> key = key;
+    node -> left = NULL;
+    node -> right = NULL;
+    return node;
 }
 
 /* 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -431,7 +431,7 @@ void lab2_tree_delete(lab2_tree *tree) { // 트리를 초기화
  *  @return                 : status(success or fail)
  */
 void lab2_node_delete(lab2_node *node) { // 삭제한 노드의 메모리 할당 제거
-    free(node);
+    // free(node);
     node = NULL;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -98,34 +98,58 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
  *  @param int key          : key value that you want to delete. 
  *  @return                 : status (success or fail)
  */
-lab2_node *lab2_node_remove(lab2_tree *tree, int key) {
-    // You need to implement lab2_node_remove function.
-    if (tree == NULL) {
-        return tree;
+int lab2_node_remove(lab2_tree *tree, int key) {
+    lab2_node *temp = tree -> root;
+    lab2_node *parent, *child = NULL;
+    if(temp == NULL) {
+        return SUCCESS;
     }
-    if (key < tree->key) {
-        tree->left = lab2_node_remove(tree->left, key);
-    } else if (key > tree->key) {
-        tree->right = lab2_node_remove(tree->right, key);
-    } else {
-        if (tree->left == NULL) { // 왼쪽 자식이 없을때
-            Node *temp = tree->right;
-            tree = NULL;
-            return temp; // 오른쪽 자식을 리턴(삭제할 노드의 부모노드와 연결)
-        } else if (tree->right == NULL) { // 오른쪽 자식이 없을때
-            Node *temp = tree->left;
-            tree = NULL;
-            return temp; // 왼쪽 자식을 리턴
+    while(temp -> key != key) {
+        if(temp -> key < key) {
+            parent = temp;
+            temp = temp -> right;
+        } else {
+            parent = temp;
+            temp = temp -> left;
         }
-        // 왼쪽과 오른쪽 자식이 모두 있는 경우
-        lab2_node *temp = tree->right;
-        while (temp->left != NULL) {
-            temp = temp->left; // 오른쪽 자식의 가장 작은 값
-        }
-        tree->key = temp->key; // 삭제할 노드의 값을 오른쪽 자식의 가장 작은 값으로 바꿈
-        tree->right = lab2_node_remove(tree->right, temp->key); // 바꾼 값을 가진 노드를 찾아서 지움
     }
-    return tree;
+    if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
+        if(parent -> left == temp) {
+            parent -> left = NULL;
+        }
+        if(parent -> right == temp) {
+            parent -> right == NULL;
+        }
+        lab2_node_delete(temp);
+        return SUCCESS;
+    }
+    if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+        if(temp -> left) {
+            child = temp -> left;
+        } else {
+            child = temp -> right;
+        }
+        if(parent -> left == temp) {
+            parent -> left = child;
+        } else {
+            parent -> right = child;
+        }
+        lab2_node_delete(temp);
+        return SUCCESS;
+    }
+    if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
+        lab2_node *temp2 = temp -> right;
+        while(temp2->left != NULL){
+            parent = temp2;
+            temp2 = temp2->left;
+        }
+        temp->key = temp2->key;
+        if(temp2->right != NULL){
+            parent->left = temp2->right;
+        }
+        lab2_node_delete(temp2);
+        return SUCCESS;
+    }
 }
 
 /* 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "lab2_sync_types.h"
+pthread_mutex_t mutexTree = PTHREAD_MUTEX_INITIALIZER;
 
 /*
  * TODO
@@ -112,7 +113,9 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
       // You need to implement lab2_node_insert_fg function.
       lab2_node *temp = tree -> root;
     if(temp == NULL) {
+        pthread_mutex_lock(&new_node -> mutex);
         tree -> root = new_node;
+        pthread_mutex_unlock(&new_node -> mutex);
     } else {
         while(1) {
             if(temp -> key < new_node -> key) {
@@ -151,11 +154,11 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
  */
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert_cg function.
-    pthread_mutex_lock(&(tree -> root) -> mutex); // lock 걸어줌
+    pthread_mutex_lock(&mutexTree); // lock 걸어줌
     lab2_node *temp = tree -> root;
     if(temp == NULL) {
         tree -> root = new_node;
-        pthread_mutex_unlock(&temp->mutex); // lock 해제
+        pthread_mutex_unlock(&mutexTree); // lock 해제
         return LAB2_SUCCESS;
     } else {
         while(1) {
@@ -174,7 +177,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
             }
         }
     }
-    pthread_mutex_unlock(&temp->mutex); // lock 해제
+   pthread_mutex_unlock(&mutexTree); // lock 해제
     return LAB2_SUCCESS;
 }
 
@@ -324,7 +327,7 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
  *  @return                 : status (success or fail)
  */
 int lab2_node_remove_cg(lab2_tree *tree, int key) {
-    pthread_mutex_lock(&(tree -> root) -> mutex);
+    pthread_mutex_lock(&mutexTree);
     lab2_node *temp = tree -> root;
     lab2_node *parent = NULL , *child, *succ, *succ_p;
     while(temp -> key != key && temp != NULL) {
@@ -332,7 +335,7 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
         temp = (key < temp -> key) ? temp->left : temp->right;
     }
     if(temp == NULL) {
-        pthread_mutex_unlock(&(tree -> root) -> mutex);
+        pthread_mutex_unlock(&mutexTree);
         return LAB2_SUCCESS;
     }
     if((temp -> left == NULL) && (temp -> right == NULL)) { // 아래에 자식 노드가 없을 경우
@@ -375,7 +378,7 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
         temp = succ;
     }
     lab2_node_delete(temp);
-    pthread_mutex_unlock(&(tree -> root) -> mutex);
+    pthread_mutex_unlock(&mutexTree);
     return LAB2_SUCCESS;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -204,7 +204,7 @@ void lab2_tree_delete(lab2_tree *tree) { // 트리를 초기화
  *  @param lab2_tree *tree  : bst node which you want to remove. 
  *  @return                 : status(success or fail)
  */
-void lab2_node_delete(lab2_node *node) {
-    // You need to implement lab2_node_delete function.
+void lab2_node_delete(lab2_node *node) { // 삭제한 노드의 메모리 할당 제거
+    free(node);
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -61,28 +61,29 @@ lab2_node * lab2_node_create(int key) {
  *  @param lab2_node *new_node  : bst node which you need to insert. 
  *  @return                 : satus (success or fail)
  */
-int lab2_node_insert(lab2_tree *tree, lab2_node *new_node){
-    // You need to implement lab2_node_insert function.
-    lab2_node * comp = this -> root; // 비교 노드를 설정
-    while(true)
-    {
-        if(comp -> data < new_node -> data) //루트의 key값보다 새로운 노드의 키값이 더 클때
-        {
-            if(comp -> right == NULL) // 루트의 오른쪽 자식이 없을 때
-            {
-                comp -> right = new_node;
-                break;
-            } else comp = comp -> right; // 비교 노드를 오른쪽 자식 노드로 변경
-            else
-            {
-                {
-                if(comp -> left == NULL)
-                    comp -> left = new_node;
+int lab2_node_insert(lab2_tree *tree, lab2_node *new_node) {
+    lab2_node *temp = tree -> root;
+    if(temp == NULL) {
+        tree -> root = new_node; // root가 NULL이면 새로운 노드를 root로 설정
+        return SUCCESS;
+    } else {
+        while(1) {
+            if(temp -> key < new_node -> key) { // 비교 노드의 키값보다 추가할 노드의 키값이 클 때
+                if(!(temp -> right)) { // 비교노드의 오른쪽 자식이 NULL 일 때
+                    temp -> right =  new_node;
                     break;
-                } else comp = comp -> left;
+                }
+                temp = temp -> right;
+            } else if(temp -> key > new_node -> key) { // 비교 노드의 키값보다 추가할 노드의 키값이 작을 때
+                if(!(temp -> left)) { // 비교노드의 왼쪽 자식이 NULL 일 때
+                    temp -> left = new_node;
+                    break;
+                }
+                temp = temp -> left;
             }
         }
     }
+    return SUCCESS;
 }
 
 /* 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -26,12 +26,14 @@
  *  @param lab2_tree *tree  : bst to print in-order. 
  *  @return                 : status (success or fail)
  */
-int lab2_node_print_inorder(lab2_tree *tree) {
-    // You need to implement lab2_node_print_inorder function.
-    if(tree == NULL) return;
-    lab2_node_print_inorder(tree -> left);
-    printf("%d ", tree -> key);
-    lab2_node_print_inorder(tree -> right);
+void inorder(lab2_node *node) {
+    if(!node) return;
+    inorder(node -> left);
+    printf("%d \n", node -> key);
+    inorder(node -> right);
+}
+int lab2_node_print_inorder(lab2_tree * tree) {
+    inorder(tree -> root);
 }
 
 /*
@@ -152,7 +154,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     lab2_node *temp = tree -> root;
     if(temp == NULL) {
         tree -> root = new_node;
-        return SUCCESS;
+        return LAB2_SUCCESS;
     } else {
         pthread_mutex_lock(&temp->mutex); // lock 걸어줌
         while(1) {
@@ -172,7 +174,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
         }
         pthread_mutex_unlock(&temp->mutex); // lock 해제
     }
-    return SUCCESS;
+    return LAB2_SUCCESS;
 }
 
 /* 
@@ -344,9 +346,9 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
     lab2_node *temp = tree -> root;
     lab2_node *parent, *child = NULL;
     if(temp == NULL) {
-        return SUCCESS;
+        return LAB2_SUCCESS
     }
-    pthread_mutex_lock(&temp->lock);
+    pthread_mutex_lock(&temp->mutex);
     while(temp -> key != key) {
         if(temp -> key < key) {
             parent = temp;
@@ -364,8 +366,8 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
             parent -> right == NULL;
         }
         lab2_node_delete(temp);
-        pthread_mutex_unlock(&temp->lock);
-        return SUCCESS;
+        pthread_mutex_unlock(&temp->mutex);
+        return LAB2_SUCCESS
     }
     if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
         if(temp -> left) {
@@ -379,8 +381,8 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
             parent -> right = child;
         }
         lab2_node_delete(temp);
-        pthread_mutex_unlock(&temp->lock);
-        return SUCCESS;
+        pthread_mutex_unlock(&temp->mutex);
+        return LAB2_SUCCESS
     }
     if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
         lab2_node *temp2 = temp -> right;
@@ -393,10 +395,10 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
             parent->left = temp2->right;
         }
         lab2_node_delete(temp2);
-        pthread_mutex_unlock(&temp->lock);
-        return SUCCESS;
+        pthread_mutex_unlock(&temp->mutex);
+        return LAB2_SUCCESS;
     }
-    pthread_mutex_lock(&temp->lock);
+    pthread_mutex_lock(&temp->mutex);
 }
 
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -39,7 +39,6 @@ int lab2_node_print_inorder(lab2_tree *tree) {
  */
 lab2_tree *lab2_tree_create() {
     // You need to implement lab2_tree_create function.
-    // mutex 함수 추가필요.
     lab2_tree *tree = (lab2_tree *) malloc(sizeof(lab2_tree));
     tree -> root = NULL;
     return tree;
@@ -55,11 +54,11 @@ lab2_tree *lab2_tree_create() {
  */
 lab2_node * lab2_node_create(int key) {
     // You need to implement lab2_node_create function.
-    // mutex 함수 추가 필요.
     lab2_node *node = (lab2_node *) malloc(sizeof(lab2_node));
     node -> key = key;
     node -> left = NULL;
     node -> right = NULL;
+    pthread_mutex_init(&node->mutex, NULL);
     return node;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -117,23 +117,26 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
         tree -> root = new_node;
         pthread_mutex_unlock(&new_node -> mutex);
     } else {
-	pthread_mutex_lock(&new_node -> mutex);
+	    
         while(1){
             if(temp -> key < new_node -> key) {
                 if(!(temp -> right)) {
+                    pthread_mutex_lock(&new_node -> mutex);
                     temp -> right =  new_node;
+                    pthread_mutex_unlock(&new_node -> mutex);
                     break;
                 }
                 temp = temp -> right;
             }else if(temp -> key > new_node -> key) {
                 if(!(temp -> left)) {
+                    pthread_mutex_lock(&new_node -> mutex);
                     temp -> left = new_node;
+                    pthread_mutex_unlock(&new_node -> mutex);
                     break;
                 }
                 temp = temp -> left;
             }
         }
-	pthread_mutex_unlock(&new_node -> mutex);
     }
     return LAB2_SUCCESS;
 }
@@ -148,11 +151,11 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
  */
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert_cg function. // lock 걸어줌
-    pthread_mutex_lock(&Mutex);
+    pthread_mutex_lock(&new_node -> mutex);
     lab2_node *temp = tree -> root;
     if(temp == NULL) {
 	tree -> root = new_node;
-	pthread_mutex_unlock(&Mutex);
+	pthread_mutex_unlock(&new_node -> mutex);
         return LAB2_SUCCESS;
     } else {
         while(1) {
@@ -171,7 +174,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
             }
         }
     }
-   pthread_mutex_unlock(&Mutex); // lock 해제
+   pthread_mutex_unlock(&new_node -> mutex); // lock 해제
     return LAB2_SUCCESS;
 }
 
@@ -248,19 +251,22 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
     // You need to implement lab2_node_remove_fg function.
     lab2_node *temp = tree -> root;
     lab2_node *parent = NULL , *child, *succ, *succ_p;
-    pthread_mutex_lock(&Mutex);
+    
     while(temp -> key != key && temp != NULL) {
+        pthread_mutex_lock(&Mutex);
         parent = temp;
         temp = (key < temp -> key) ? temp->left : temp->right;
+        pthread_mutex_unlock(&Mutex);
     }
-    pthread_mutex_unlock(&Mutex);
+    
     pthread_mutex_lock(&Mutex);
     if(temp == NULL) {
         return LAB2_SUCCESS;
     }
     pthread_mutex_unlock(&Mutex);
-    pthread_mutex_lock(&Mutex);
+    
     if((temp -> left == NULL) && (temp -> right == NULL)) { // 아래에 자식 노드가 없을 경우
+    pthread_mutex_lock(&Mutex);
         if (parent != NULL)
         {
             if(parent -> left == temp) {
@@ -273,6 +279,7 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
         }
         pthread_mutex_unlock(&Mutex);
     } else if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+        pthread_mutex_lock(&Mutex);
         child = (temp -> left != NULL) ? temp -> left : temp -> right;
         if(parent != NULL) {
             if(parent -> left == temp) {
@@ -285,6 +292,7 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
         }
         pthread_mutex_unlock(&Mutex);
     } else {
+        pthread_mutex_lock(&Mutex);
           // 아래에 2개의 자식 노드가 있을 경우
         succ_p = temp;
         succ = temp -> right;

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -28,6 +28,10 @@
  */
 int lab2_node_print_inorder(lab2_tree *tree) {
     // You need to implement lab2_node_print_inorder function.
+    if(tree == NULL) return;
+    lab2_node_print_inorder(tree -> left);
+    printf("%d ", tree -> key);
+    lab2_node_print_inorder(tree -> right);
 }
 
 /*

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -98,8 +98,9 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
  *  @param int key          : key value that you want to delete. 
  *  @return                 : status (success or fail)
  */
-int lab2_node_remove(lab2_tree *tree, int key) {
+lab2_node *lab2_node_remove(lab2_tree *tree, int key) {
     // You need to implement lab2_node_remove function.
+    
 }
 
 /* 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -198,7 +198,11 @@ int lab2_node_remove(lab2_tree *tree, int key) {
     lab2_node *parent = NULL , *child, *succ, *succ_p;
     while(temp != NULL && (temp -> key != key)) {
         parent = temp;
-        temp = (key < temp -> key) ? temp->left : temp->right;
+        if(temp -> key < key) {
+            temp = temp -> right;
+        } else {
+            temp = temp -> left;
+        }
     }
     if(temp == NULL) {
         return LAB2_SUCCESS;
@@ -262,7 +266,11 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
     pthread_mutex_lock(&tree -> mutex);
     while(temp != NULL && temp -> key != key) {
         parent = temp;
-        temp = (key < temp -> key) ? temp->left : temp->right;
+        if(temp -> key < key) {
+            temp = temp -> right;
+        } else {
+            temp = temp -> left;
+        }
     }
     pthread_mutex_unlock(&tree -> mutex);
     
@@ -337,7 +345,11 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
     lab2_node *parent = NULL , *child, *succ, *succ_p;
     while(temp != NULL && temp -> key != key) {
         parent = temp;
-        temp = (key < temp -> key) ? temp->left : temp->right;
+        if(temp -> key < key) {
+            temp = temp -> right;
+        } else {
+            temp = temp -> left;
+        }
     }
     if(temp == NULL) {
         pthread_mutex_unlock(&Mutex);

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -240,6 +240,7 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
             parent -> right == NULL;
         }
         lab2_node_delete(temp);
+        pthread_mutex_unlock(&temp->lock);
         return SUCCESS;
     }
     if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
@@ -254,6 +255,7 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
             parent -> right = child;
         }
         lab2_node_delete(temp);
+        pthread_mutex_unlock(&temp->lock);
         return SUCCESS;
     }
     if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
@@ -267,9 +269,10 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
             parent->left = temp2->right;
         }
         lab2_node_delete(temp2);
+        pthread_mutex_unlock(&temp->lock);
         return SUCCESS;
     }
-    pthread_mutex_unlock(&temp->lock);
+    pthread_mutex_lock(&temp->lock);
 }
 
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -187,7 +187,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
  */
 int lab2_node_remove(lab2_tree *tree, int key) {
     lab2_node *temp = tree -> root;
-    lab2_node *parent, *child = NULL;
+    lab2_node *parent = NULL , *child, *succ, *succ_p;
     while(temp -> key != key && temp != NULL) {
         parent = temp;
         temp = (key < temp -> key) ? temp->left : temp->right;
@@ -195,43 +195,46 @@ int lab2_node_remove(lab2_tree *tree, int key) {
     if(temp == NULL) {
         return LAB2_SUCCESS;
     }
-    if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
-        if(parent -> left == temp) {
-            parent -> left = NULL;
-        }
-        if(parent -> right == temp) {
-            parent -> right = NULL;
-        }
-        lab2_node_delete(temp);
-        return LAB2_SUCCESS;
-    }
-    if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
-        if(temp -> left) {
-            child = temp -> left;
+    if((temp -> left == NULL) && (temp -> right == NULL)) { // 아래에 자식 노드가 없을 경우
+        if (parent != NULL)
+        {
+            if(parent -> left == temp) {
+                parent -> left = NULL;
+            } else {
+                parent -> right = NULL;
+            }
         } else {
-            child = temp -> right;
+            tree -> root = NULL;
         }
-        if(parent -> left == temp) {
-            parent -> left = child;
+        
+    } else if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+        child = (temp -> left != NULL) ? temp -> left : temp -> right;
+        if(parent != NULL) {
+            if(parent -> left == temp) {
+                parent -> left = child;
+            } else {
+                parent -> right = child;
+            }
         } else {
-            parent -> right = child;
+            tree -> root = child;
         }
-        lab2_node_delete(temp);
-        return LAB2_SUCCESS;
+    } else {
+          // 아래에 2개의 자식 노드가 있을 경우
+        succ_p = temp;
+        succ = temp -> right;
+        while(succ -> left != NULL) {
+            succ_p = succ;
+            succ = succ -> left;
+        }
+        if(succ_p -> left == succ) {
+            succ_p -> left = succ -> right;
+        } else {
+            succ_p -> right = succ -> right;
+        }
+        temp -> key = succ -> key;
+        temp = succ;
     }
-    if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
-        lab2_node *temp2 = temp -> right;
-        while(temp2->left != NULL){
-            parent = temp2;
-            temp2 = temp2->left;
-        }
-        temp->key = temp2->key;
-        if(temp2->right != NULL){
-            parent->left = temp2->right;
-        }
-        lab2_node_delete(temp2);
-        return LAB2_SUCCESS;
-    }
+    lab2_node_delete(temp);
     return LAB2_SUCCESS;
 }
 
@@ -426,7 +429,7 @@ void lab2_tree_delete(lab2_tree *tree) { // 트리를 초기화
  *  @return                 : status(success or fail)
  */
 void lab2_node_delete(lab2_node *node) { // 삭제한 노드의 메모리 할당 제거
-    // free(node);
+    free(node);
     node = NULL;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -216,6 +216,73 @@ int lab2_node_remove(lab2_tree *tree, int key) {
  */
 int lab2_node_remove_fg(lab2_tree *tree, int key) {
     // You need to implement lab2_node_remove_fg function.
+    lab2_node *temp = tree -> root;
+    lab2_node *parent, *child = NULL;
+    int result;
+    if(temp == NULL) {
+        return LAB2_SUCCESS;
+    }
+    while(temp -> key != key) {
+        pthread_mutex_lock(&temp -> mutex);
+        if(temp -> key < key) {
+            parent = temp;
+            temp = temp -> right;
+        } else {
+            parent = temp;
+            temp = temp -> left;
+        }
+        pthread_mutex_unlock(&temp -> mutex);
+    }
+    if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
+        pthread_mutex_lock(&temp -> mutex);
+        if(parent -> left == temp) {
+            parent -> left = NULL;
+        }
+        if(parent -> right == temp) {
+            parent -> right == NULL;
+        }
+        lab2_node_delete(temp);
+        pthread_mutex_unlock(&temp -> mutex);
+        return LAB2_SUCCESS;
+    }
+    if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+        pthread_mutex_lock(&temp -> mutex);
+        if(temp -> left) {
+            child = temp -> left;
+        } else {
+            child = temp -> right;
+        }
+        if(parent -> left == temp) {
+            parent -> left = child;
+        } else {
+            parent -> right = child;
+        }
+        lab2_node_delete(temp);
+        pthread_mutex_unlock(&temp -> mutex);
+        return LAB2_SUCCESS;
+    }
+    if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
+        lab2_node *temp2 = temp -> right;
+        while(temp2->left != NULL){
+            pthread_mutex_lock(&temp -> mutex);
+            parent = temp2;
+            temp2 = temp2->left;
+            pthread_mutex_unlock(&temp -> mutex);
+        }
+        pthread_mutex_lock(&temp -> mutex);
+        temp->key = temp2->key;
+        pthread_mutex_unlock(&temp -> mutex);
+        if(temp2->right != NULL){
+            pthread_mutex_lock(&temp -> mutex);
+            parent->left = temp2->right;
+            pthread_mutex_unlock(&temp -> mutex);
+        }
+        pthread_mutex_lock(&temp -> mutex);
+        lab2_node_delete(temp2);
+        pthread_mutex_unlock(&temp -> mutex);
+        return LAB2_SUCCESS;
+    }
+
 }
 
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -156,11 +156,11 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
  */
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert_cg function. // lock 걸어줌
-    pthread_mutex_lock(&new_node -> mutex);
+    pthread_mutex_lock(&Mutex);
     lab2_node *temp = tree -> root;
     if(temp == NULL) {
 	tree -> root = new_node;
-	pthread_mutex_unlock(&new_node -> mutex);
+	pthread_mutex_unlock(&Mutex);
     return LAB2_SUCCESS;
     } else {
         while(1) {
@@ -181,7 +181,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
             }
         }
     }
-   pthread_mutex_unlock(&new_node -> mutex); // lock 해제
+   pthread_mutex_unlock(&Mutex); // lock 해제
     return LAB2_SUCCESS;
 }
 
@@ -267,11 +267,12 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
     if(temp == NULL) {
         return LAB2_SUCCESS;
     }
+    pthread_mutex_lock(&tree -> mutex);
     
     if((temp -> left == NULL) && (temp -> right == NULL)) { // 아래에 자식 노드가 없을 경우
         if (parent != NULL)
         {
-            pthread_mutex_lock(&tree -> mutex);
+            
             if(parent -> left == temp) {
                 parent -> left = NULL;
             } else {
@@ -279,14 +280,12 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
             }
             pthread_mutex_unlock(&tree -> mutex);
         } else {
-            pthread_mutex_lock(&tree -> mutex);   
             tree -> root = NULL;
             pthread_mutex_unlock(&tree -> mutex);
         }
     } else if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
         child = (temp -> left != NULL) ? temp -> left : temp -> right;
         if(parent != NULL) {
-            pthread_mutex_lock(&tree ->mutex);
             if(parent -> left == temp) {
                 parent -> left = child;
             } else {
@@ -294,13 +293,11 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
             }
             pthread_mutex_unlock(&tree ->mutex);
         } else {
-            pthread_mutex_lock(&tree ->mutex);
             tree -> root = child;
             pthread_mutex_unlock(&tree ->mutex);
         }
     } else {
           // 아래에 2개의 자식 노드가 있을 경우
-        pthread_mutex_lock(&tree -> mutex);
         succ_p = temp;
         succ = temp -> right;
         while(succ -> left != NULL) {
@@ -312,8 +309,6 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
         } else {
             succ_p -> right = succ -> right;
         }
-        pthread_mutex_unlock(&tree -> mutex);
-        pthread_mutex_lock(&tree -> mutex);
         temp -> key = succ -> key;
         temp = succ;
         pthread_mutex_unlock(&tree -> mutex);

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -110,19 +110,23 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
     } else {
         while(1) {
             if(temp -> key < new_node -> key) {
-                pthread_mutex_lock(&temp -> mutex);
                 if(!(temp -> right)) {
+                    pthread_mutex_lock(&temp -> mutex);
                     temp -> right =  new_node;
+                    pthread_mutex_unlock(&temp -> mutex);
                     break;
                 }
+                pthread_mutex_lock(&temp -> mutex);
                 temp = temp -> right;
                 pthread_mutex_unlock(&temp -> mutex);
             } else if(temp -> key > new_node -> key) {
-                pthread_mutex_lock(&temp -> mutex);
                 if(!(temp -> left)) {
+                    pthread_mutex_lock(&temp -> mutex);
                     temp -> left = new_node;
+                    pthread_mutex_unlock(&temp -> mutex);
                     break;
                 }
+                pthread_mutex_lock(&temp -> mutex);
                 temp = temp -> left;
                 pthread_mutex_unlock(&temp -> mutex);
             }
@@ -223,40 +227,55 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
         return LAB2_SUCCESS;
     }
     while(temp -> key != key) {
-        pthread_mutex_lock(&temp -> mutex);
         if(temp -> key < key) {
+            pthread_mutex_lock(&temp -> mutex);
             parent = temp;
             temp = temp -> right;
+            pthread_mutex_unlock(&temp -> mutex);
         } else {
+            pthread_mutex_lock(&temp -> mutex);
             parent = temp;
             temp = temp -> left;
+            pthread_mutex_unlock(&temp -> mutex);
         }
-        pthread_mutex_unlock(&temp -> mutex);
+        
     }
     if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
-        pthread_mutex_lock(&temp -> mutex);
         if(parent -> left == temp) {
+            pthread_mutex_lock(&temp -> mutex);
             parent -> left = NULL;
+            pthread_mutex_unlock(&temp -> mutex);
         }
         if(parent -> right == temp) {
+            pthread_mutex_lock(&temp -> mutex);
             parent -> right == NULL;
+            pthread_mutex_unlock(&temp -> mutex);
         }
+        pthread_mutex_lock(&temp -> mutex);
         lab2_node_delete(temp);
         pthread_mutex_unlock(&temp -> mutex);
         return LAB2_SUCCESS;
     }
     if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
-        pthread_mutex_lock(&temp -> mutex);
         if(temp -> left) {
+            pthread_mutex_lock(&temp -> mutex);
             child = temp -> left;
+            pthread_mutex_unlock(&temp -> mutex);
         } else {
+            pthread_mutex_lock(&temp -> mutex);
             child = temp -> right;
+            pthread_mutex_unlock(&temp -> mutex);
         }
         if(parent -> left == temp) {
+            pthread_mutex_lock(&temp -> mutex);
             parent -> left = child;
+            pthread_mutex_unlock(&temp -> mutex);
         } else {
+            pthread_mutex_lock(&temp -> mutex);
             parent -> right = child;
+            pthread_mutex_unlock(&temp -> mutex);
         }
+        pthread_mutex_lock(&temp -> mutex);
         lab2_node_delete(temp);
         pthread_mutex_unlock(&temp -> mutex);
         return LAB2_SUCCESS;

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -149,9 +149,10 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert_cg function. // lock 걸어줌
     lab2_node *temp = tree -> root;
+    pthread_mutex_lock(&new_node -> mutex);
     if(temp == NULL) {
-	pthread_mutex_lock(&new_node -> mutex);
-        tree -> root = new_node;// lock 해제
+	tree -> root = new_node;
+	pthread_mutex_unlock(&new_node -> mutex);
         return LAB2_SUCCESS;
     } else {
         while(1) {

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -110,34 +110,34 @@ int lab2_node_insert(lab2_tree *tree, lab2_node *new_node) {
  */
 int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
       // You need to implement lab2_node_insert_fg function.
-      lab2_node *temp = tree -> root;
-    if(temp == NULL) {
-        tree -> root = new_node;
-    } else {
-        while(1) {
-            if(temp -> key < new_node -> key) {
-                if(!(temp -> right)) {
-                    pthread_mutex_lock(&temp -> mutex);
-                    temp -> right =  new_node;
-                    pthread_mutex_unlock(&temp -> mutex);
-                    break;
-                }
-                pthread_mutex_lock(&temp -> mutex);
-                temp = temp -> right;
-                pthread_mutex_unlock(&temp -> mutex);
-            } else if(temp -> key > new_node -> key) {
-                if(!(temp -> left)) {
-                    pthread_mutex_lock(&temp -> mutex);
-                    temp -> left = new_node;
-                    pthread_mutex_unlock(&temp -> mutex);
-                    break;
-                }
-                pthread_mutex_lock(&temp -> mutex);
-                temp = temp -> left;
-                pthread_mutex_unlock(&temp -> mutex);
-            }
-        }
-    }
+    //   lab2_node *temp = tree -> root;
+    // if(temp == NULL) {
+    //     tree -> root = new_node;
+    // } else {
+    //     while(1) {
+    //         if(temp -> key < new_node -> key) {
+    //             if(!(temp -> right)) {
+    //                 pthread_mutex_lock(&temp -> mutex);
+    //                 temp -> right =  new_node;
+    //                 pthread_mutex_unlock(&temp -> mutex);
+    //                 break;
+    //             }
+    //             pthread_mutex_lock(&temp -> mutex);
+    //             temp = temp -> right;
+    //             pthread_mutex_unlock(&temp -> mutex);
+    //         } else if(temp -> key > new_node -> key) {
+    //             if(!(temp -> left)) {
+    //                 pthread_mutex_lock(&temp -> mutex);
+    //                 temp -> left = new_node;
+    //                 pthread_mutex_unlock(&temp -> mutex);
+    //                 break;
+    //             }
+    //             pthread_mutex_lock(&temp -> mutex);
+    //             temp = temp -> left;
+    //             pthread_mutex_unlock(&temp -> mutex);
+    //         }
+    //     }
+    // }
     return LAB2_SUCCESS;
 }
 
@@ -151,29 +151,29 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
  */
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert_cg function.
-    lab2_node *temp = tree -> root;
-    if(temp == NULL) {
-        tree -> root = new_node;
-        return LAB2_SUCCESS;
-    } else {
-        pthread_mutex_lock(&temp->mutex); // lock 걸어줌
-        while(1) {
-            if(temp -> key < new_node -> key) {
-                if(!(temp -> right)) {
-                    temp -> right =  new_node;
-                    break;
-                }
-                temp = temp -> right;
-            } else if(temp -> key > new_node -> key) {
-                if(!(temp -> left)) {
-                    temp -> left = new_node;
-                    break;
-                }
-                temp = temp -> left;
-            }
-        }
-        pthread_mutex_unlock(&temp->mutex); // lock 해제
-    }
+    // lab2_node *temp = tree -> root;
+    // if(temp == NULL) {
+    //     tree -> root = new_node;
+    //     return LAB2_SUCCESS;
+    // } else {
+    //     pthread_mutex_lock(&temp->mutex); // lock 걸어줌
+    //     while(1) {
+    //         if(temp -> key < new_node -> key) {
+    //             if(!(temp -> right)) {
+    //                 temp -> right =  new_node;
+    //                 break;
+    //             }
+    //             temp = temp -> right;
+    //         } else if(temp -> key > new_node -> key) {
+    //             if(!(temp -> left)) {
+    //                 temp -> left = new_node;
+    //                 break;
+    //             }
+    //             temp = temp -> left;
+    //         }
+    //     }
+    //     pthread_mutex_unlock(&temp->mutex); // lock 해제
+    // }
     return LAB2_SUCCESS;
 }
 
@@ -188,17 +188,12 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
 int lab2_node_remove(lab2_tree *tree, int key) {
     lab2_node *temp = tree -> root;
     lab2_node *parent, *child = NULL;
+    while(temp -> key != key && temp != NULL) {
+        parent = temp;
+        temp = (key < temp -> key) ? temp->left : temp->right;
+    }
     if(temp == NULL) {
         return LAB2_SUCCESS;
-    }
-    while(temp -> key != key) {
-        if(temp -> key < key) {
-            parent = temp;
-            temp = temp -> right;
-        } else {
-            parent = temp;
-            temp = temp -> left;
-        }
     }
     if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
         if(parent -> left == temp) {
@@ -250,87 +245,87 @@ int lab2_node_remove(lab2_tree *tree, int key) {
  */
 int lab2_node_remove_fg(lab2_tree *tree, int key) {
     // You need to implement lab2_node_remove_fg function.
-    lab2_node *temp = tree -> root;
-    lab2_node *parent, *child = NULL;
-    int result;
-    if(temp == NULL) {
-        return LAB2_SUCCESS;
-    }
-    while(temp -> key != key) {
-        if(temp -> key < key) {
-            pthread_mutex_lock(&temp -> mutex);
-            parent = temp;
-            temp = temp -> right;
-            pthread_mutex_unlock(&temp -> mutex);
-        } else {
-            pthread_mutex_lock(&temp -> mutex);
-            parent = temp;
-            temp = temp -> left;
-            pthread_mutex_unlock(&temp -> mutex);
-        }
+    // lab2_node *temp = tree -> root;
+    // lab2_node *parent, *child = NULL;
+    // int result;
+    // if(temp == NULL) {
+    //     return LAB2_SUCCESS;
+    // }
+    // while(temp -> key != key) {
+    //     if(temp -> key < key) {
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         parent = temp;
+    //         temp = temp -> right;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     } else {
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         parent = temp;
+    //         temp = temp -> left;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     }
         
-    }
-    if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
-        if(parent -> left == temp) {
-            pthread_mutex_lock(&temp -> mutex);
-            parent -> left = NULL;
-            pthread_mutex_unlock(&temp -> mutex);
-        }
-        if(parent -> right == temp) {
-            pthread_mutex_lock(&temp -> mutex);
-            parent -> right = NULL;
-            pthread_mutex_unlock(&temp -> mutex);
-        }
-        pthread_mutex_lock(&temp -> mutex);
-        lab2_node_delete(temp);
-        pthread_mutex_unlock(&temp -> mutex);
-        return LAB2_SUCCESS;
-    }
-    if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
-        if(temp -> left) {
-            pthread_mutex_lock(&temp -> mutex);
-            child = temp -> left;
-            pthread_mutex_unlock(&temp -> mutex);
-        } else {
-            pthread_mutex_lock(&temp -> mutex);
-            child = temp -> right;
-            pthread_mutex_unlock(&temp -> mutex);
-        }
-        if(parent -> left == temp) {
-            pthread_mutex_lock(&temp -> mutex);
-            parent -> left = child;
-            pthread_mutex_unlock(&temp -> mutex);
-        } else {
-            pthread_mutex_lock(&temp -> mutex);
-            parent -> right = child;
-            pthread_mutex_unlock(&temp -> mutex);
-        }
-        pthread_mutex_lock(&temp -> mutex);
-        lab2_node_delete(temp);
-        pthread_mutex_unlock(&temp -> mutex);
-        return LAB2_SUCCESS;
-    }
-    if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
-        lab2_node *temp2 = temp -> right;
-        while(temp2->left != NULL){
-            pthread_mutex_lock(&temp -> mutex);
-            parent = temp2;
-            temp2 = temp2->left;
-            pthread_mutex_unlock(&temp -> mutex);
-        }
-        pthread_mutex_lock(&temp -> mutex);
-        temp->key = temp2->key;
-        pthread_mutex_unlock(&temp -> mutex);
-        if(temp2->right != NULL){
-            pthread_mutex_lock(&temp -> mutex);
-            parent->left = temp2->right;
-            pthread_mutex_unlock(&temp -> mutex);
-        }
-        pthread_mutex_lock(&temp -> mutex);
-        lab2_node_delete(temp2);
-        pthread_mutex_unlock(&temp -> mutex);
-        return LAB2_SUCCESS;
-    }
+    // }
+    // if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
+    //     if(parent -> left == temp) {
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         parent -> left = NULL;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     }
+    //     if(parent -> right == temp) {
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         parent -> right = NULL;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     }
+    //     pthread_mutex_lock(&temp -> mutex);
+    //     lab2_node_delete(temp);
+    //     pthread_mutex_unlock(&temp -> mutex);
+    //     return LAB2_SUCCESS;
+    // }
+    // if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+    //     if(temp -> left) {
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         child = temp -> left;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     } else {
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         child = temp -> right;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     }
+    //     if(parent -> left == temp) {
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         parent -> left = child;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     } else {
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         parent -> right = child;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     }
+    //     pthread_mutex_lock(&temp -> mutex);
+    //     lab2_node_delete(temp);
+    //     pthread_mutex_unlock(&temp -> mutex);
+    //     return LAB2_SUCCESS;
+    // }
+    // if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
+    //     lab2_node *temp2 = temp -> right;
+    //     while(temp2->left != NULL){
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         parent = temp2;
+    //         temp2 = temp2->left;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     }
+    //     pthread_mutex_lock(&temp -> mutex);
+    //     temp->key = temp2->key;
+    //     pthread_mutex_unlock(&temp -> mutex);
+    //     if(temp2->right != NULL){
+    //         pthread_mutex_lock(&temp -> mutex);
+    //         parent->left = temp2->right;
+    //         pthread_mutex_unlock(&temp -> mutex);
+    //     }
+    //     pthread_mutex_lock(&temp -> mutex);
+    //     lab2_node_delete(temp2);
+    //     pthread_mutex_unlock(&temp -> mutex);
+    //     return LAB2_SUCCESS;
+    // }
     return LAB2_SUCCESS;
 }
 
@@ -344,62 +339,62 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
  *  @return                 : status (success or fail)
  */
 int lab2_node_remove_cg(lab2_tree *tree, int key) {
-    lab2_node *temp = tree -> root;
-    lab2_node *parent, *child = NULL;
-    if(temp == NULL) {
-        return LAB2_SUCCESS;
-    }
-    pthread_mutex_lock(&temp->mutex);
-    while(temp -> key != key) {
-        if(temp -> key < key) {
-            parent = temp;
-            temp = temp -> right;
-        } else {
-            parent = temp;
-            temp = temp -> left;
-        }
-    }
-    if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
-        if(parent -> left == temp) {
-            parent -> left = NULL;
-        }
-        if(parent -> right == temp) {
-            parent -> right = NULL;
-        }
-        lab2_node_delete(temp);
-        pthread_mutex_unlock(&temp->mutex);
-        return LAB2_SUCCESS;
-    }
-    if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
-        if(temp -> left) {
-            child = temp -> left;
-        } else {
-            child = temp -> right;
-        }
-        if(parent -> left == temp) {
-            parent -> left = child;
-        } else {
-            parent -> right = child;
-        }
-        lab2_node_delete(temp);
-        pthread_mutex_unlock(&temp->mutex);
-        return LAB2_SUCCESS;
-    }
-    if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
-        lab2_node *temp2 = temp -> right;
-        while(temp2->left != NULL){
-            parent = temp2;
-            temp2 = temp2->left;
-        }
-        temp->key = temp2->key;
-        if(temp2->right != NULL){
-            parent->left = temp2->right;
-        }
-        lab2_node_delete(temp2);
-        pthread_mutex_unlock(&temp->mutex);
-        return LAB2_SUCCESS;
-    }
-    pthread_mutex_lock(&temp->mutex);
+    // lab2_node *temp = tree -> root;
+    // lab2_node *parent, *child = NULL;
+    // if(temp == NULL) {
+    //     return LAB2_SUCCESS;
+    // }
+    // pthread_mutex_lock(&temp->mutex);
+    // while(temp -> key != key) {
+    //     if(temp -> key < key) {
+    //         parent = temp;
+    //         temp = temp -> right;
+    //     } else {
+    //         parent = temp;
+    //         temp = temp -> left;
+    //     }
+    // }
+    // if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
+    //     if(parent -> left == temp) {
+    //         parent -> left = NULL;
+    //     }
+    //     if(parent -> right == temp) {
+    //         parent -> right = NULL;
+    //     }
+    //     lab2_node_delete(temp);
+    //     pthread_mutex_unlock(&temp->mutex);
+    //     return LAB2_SUCCESS;
+    // }
+    // if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+    //     if(temp -> left) {
+    //         child = temp -> left;
+    //     } else {
+    //         child = temp -> right;
+    //     }
+    //     if(parent -> left == temp) {
+    //         parent -> left = child;
+    //     } else {
+    //         parent -> right = child;
+    //     }
+    //     lab2_node_delete(temp);
+    //     pthread_mutex_unlock(&temp->mutex);
+    //     return LAB2_SUCCESS;
+    // }
+    // if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
+    //     lab2_node *temp2 = temp -> right;
+    //     while(temp2->left != NULL){
+    //         parent = temp2;
+    //         temp2 = temp2->left;
+    //     }
+    //     temp->key = temp2->key;
+    //     if(temp2->right != NULL){
+    //         parent->left = temp2->right;
+    //     }
+    //     lab2_node_delete(temp2);
+    //     pthread_mutex_unlock(&temp->mutex);
+    //     return LAB2_SUCCESS;
+    // }
+    // pthread_mutex_lock(&temp->mutex);
     return LAB2_SUCCESS;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -29,7 +29,6 @@
 void inorder(lab2_node *node) {
     if(!node) return;
     inorder(node -> left);
-    printf("%d \n", node -> key);
     inorder(node -> right);
 }
 int lab2_node_print_inorder(lab2_tree * tree) {

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -65,7 +65,6 @@ int lab2_node_insert(lab2_tree *tree, lab2_node *new_node) {
     lab2_node *temp = tree -> root;
     if(temp == NULL) {
         tree -> root = new_node; // root가 NULL이면 새로운 노드를 root로 설정
-        return SUCCESS;
     } else {
         while(1) {
             if(temp -> key < new_node -> key) { // 비교 노드의 키값보다 추가할 노드의 키값이 클 때

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -196,7 +196,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
 int lab2_node_remove(lab2_tree *tree, int key) {
     lab2_node *temp = tree -> root;
     lab2_node *parent = NULL , *child, *succ, *succ_p;
-    while(temp -> key != key && temp != NULL) {
+    while(temp != NULL && (temp -> key != key)) {
         parent = temp;
         temp = (key < temp -> key) ? temp->left : temp->right;
     }
@@ -259,7 +259,7 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
     lab2_node *temp = tree -> root;
     lab2_node *parent = NULL , *child, *succ, *succ_p;
     
-    while(temp -> key != key && temp != NULL) {
+    while(temp != NULL && temp -> key != key) {
         parent = temp;
         temp = (key < temp -> key) ? temp->left : temp->right;
     }
@@ -300,13 +300,13 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
         }
     } else {
           // 아래에 2개의 자식 노드가 있을 경우
+        pthread_mutex_lock(&tree -> mutex);
         succ_p = temp;
         succ = temp -> right;
         while(succ -> left != NULL) {
             succ_p = succ;
             succ = succ -> left;
         }
-        pthread_mutex_lock(&tree -> mutex);
         if(succ_p -> left == succ) {
             succ_p -> left = succ -> right;
         } else {
@@ -338,7 +338,7 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
     pthread_mutex_lock(&Mutex);
     lab2_node *temp = tree -> root;
     lab2_node *parent = NULL , *child, *succ, *succ_p;
-    while(temp -> key != key && temp != NULL) {
+    while(temp != NULL && temp -> key != key) {
         parent = temp;
         temp = (key < temp -> key) ? temp->left : temp->right;
     }

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -217,7 +217,59 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
  *  @return                 : status (success or fail)
  */
 int lab2_node_remove_cg(lab2_tree *tree, int key) {
-    // You need to implement lab2_node_remove_cg function.
+    lab2_node *temp = tree -> root;
+    lab2_node *parent, *child = NULL;
+    if(temp == NULL) {
+        return SUCCESS;
+    }
+    pthread_mutex_lock(&temp->lock);
+    while(temp -> key != key) {
+        if(temp -> key < key) {
+            parent = temp;
+            temp = temp -> right;
+        } else {
+            parent = temp;
+            temp = temp -> left;
+        }
+    }
+    if(temp -> left == NULL && temp -> right == NULL) { // 아래에 자식 노드가 없을 경우
+        if(parent -> left == temp) {
+            parent -> left = NULL;
+        }
+        if(parent -> right == temp) {
+            parent -> right == NULL;
+        }
+        lab2_node_delete(temp);
+        return SUCCESS;
+    }
+    if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
+        if(temp -> left) {
+            child = temp -> left;
+        } else {
+            child = temp -> right;
+        }
+        if(parent -> left == temp) {
+            parent -> left = child;
+        } else {
+            parent -> right = child;
+        }
+        lab2_node_delete(temp);
+        return SUCCESS;
+    }
+    if(temp -> left != NULL && temp -> right != NULL) { // 아래에 2개의 자식 노드가 있을 경우
+        lab2_node *temp2 = temp -> right;
+        while(temp2->left != NULL){
+            parent = temp2;
+            temp2 = temp2->left;
+        }
+        temp->key = temp2->key;
+        if(temp2->right != NULL){
+            parent->left = temp2->right;
+        }
+        lab2_node_delete(temp2);
+        return SUCCESS;
+    }
+    pthread_mutex_unlock(&temp->lock);
 }
 
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -96,6 +96,8 @@ int lab2_node_insert(lab2_tree *tree, lab2_node *new_node) {
                     break;
                 }
                 temp = temp -> left;
+            } else {
+                break;
             }
         }
     }
@@ -114,28 +116,30 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
       // You need to implement lab2_node_insert_fg function.
       lab2_node *temp = tree -> root;
     if(temp == NULL) {
-        pthread_mutex_lock(&new_node -> mutex);
+        pthread_mutex_lock(&tree -> mutex);
         tree -> root = new_node;
-        pthread_mutex_unlock(&new_node -> mutex);
+        pthread_mutex_unlock(&tree -> mutex);
     } else {
 	    
         while(1){
             if(temp -> key < new_node -> key) {
                 if(!(temp -> right)) {
-                    pthread_mutex_lock(&(tree) -> mutex);
+                    pthread_mutex_lock(&temp -> mutex);
                     temp -> right =  new_node;
-                    pthread_mutex_unlock(&(tree) -> mutex);
+                    pthread_mutex_unlock(&temp -> mutex);
                     break;
                 }
                 temp = temp -> right;
             }else if(temp -> key > new_node -> key) {
                 if(!(temp -> left)) {
-                    pthread_mutex_lock(&(tree) -> mutex);
+                    pthread_mutex_lock(&temp -> mutex);
                     temp -> left = new_node;
-                    pthread_mutex_unlock(&(tree) -> mutex);
+                    pthread_mutex_unlock(&temp -> mutex);
                     break;
                 }
                 temp = temp -> left;
+            } else {
+                break;
             }
         }
     }
@@ -157,7 +161,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     if(temp == NULL) {
 	tree -> root = new_node;
 	pthread_mutex_unlock(&new_node -> mutex);
-        return LAB2_SUCCESS;
+    return LAB2_SUCCESS;
     } else {
         while(1) {
             if(temp -> key < new_node -> key) {
@@ -172,6 +176,8 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
                     break;
                 }
                 temp = temp -> left;
+            } else {
+                break;
             }
         }
     }
@@ -254,10 +260,8 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
     lab2_node *parent = NULL , *child, *succ, *succ_p;
     
     while(temp -> key != key && temp != NULL) {
-        pthread_mutex_lock(&Mutex);
         parent = temp;
         temp = (key < temp -> key) ? temp->left : temp->right;
-        pthread_mutex_unlock(&Mutex);
     }
     
     if(temp == NULL) {
@@ -265,33 +269,36 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
     }
     
     if((temp -> left == NULL) && (temp -> right == NULL)) { // 아래에 자식 노드가 없을 경우
-        pthread_mutex_lock(&Mutex);
         if (parent != NULL)
         {
+            pthread_mutex_lock(&tree -> mutex);
             if(parent -> left == temp) {
                 parent -> left = NULL;
             } else {
                 parent -> right = NULL;
             }
+            pthread_mutex_unlock(&tree -> mutex);
         } else {
+            pthread_mutex_lock(&tree -> mutex);   
             tree -> root = NULL;
+            pthread_mutex_unlock(&tree -> mutex);
         }
-        pthread_mutex_unlock(&Mutex);
     } else if(temp -> left == NULL || temp -> right == NULL) { // 아래에 1개의 자식 노드가 있을 경우
-        pthread_mutex_lock(&Mutex);
         child = (temp -> left != NULL) ? temp -> left : temp -> right;
         if(parent != NULL) {
+            pthread_mutex_lock(&tree ->mutex);
             if(parent -> left == temp) {
                 parent -> left = child;
             } else {
                 parent -> right = child;
             }
+            pthread_mutex_unlock(&tree ->mutex);
         } else {
+            pthread_mutex_lock(&tree ->mutex);
             tree -> root = child;
+            pthread_mutex_unlock(&tree ->mutex);
         }
-        pthread_mutex_unlock(&Mutex);
     } else {
-        pthread_mutex_lock(&Mutex);
           // 아래에 2개의 자식 노드가 있을 경우
         succ_p = temp;
         succ = temp -> right;
@@ -299,16 +306,22 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
             succ_p = succ;
             succ = succ -> left;
         }
+        pthread_mutex_lock(&tree -> mutex);
         if(succ_p -> left == succ) {
             succ_p -> left = succ -> right;
         } else {
             succ_p -> right = succ -> right;
         }
+        pthread_mutex_unlock(&tree -> mutex);
+        pthread_mutex_lock(&tree -> mutex);
         temp -> key = succ -> key;
         temp = succ;
-        pthread_mutex_unlock(&Mutex);
+        pthread_mutex_unlock(&tree -> mutex);
+    
     }
+    pthread_mutex_lock(&tree -> mutex);
     lab2_node_delete(temp);
+    pthread_mutex_unlock(&tree -> mutex);
     return LAB2_SUCCESS;
 }
 
@@ -405,7 +418,7 @@ void lab2_tree_delete(lab2_tree *tree) { // 트리를 초기화
  *  @return                 : status(success or fail)
  */
 void lab2_node_delete(lab2_node *node) { // 삭제한 노드의 메모리 할당 제거
-    // free(node);
+    free(node);
     node = NULL;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -148,11 +148,11 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
  */
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
     // You need to implement lab2_node_insert_cg function. // lock 걸어줌
+    pthread_mutex_lock(&Mutex);
     lab2_node *temp = tree -> root;
-    pthread_mutex_lock(&new_node -> mutex);
     if(temp == NULL) {
 	tree -> root = new_node;
-	pthread_mutex_unlock(&new_node -> mutex);
+	pthread_mutex_unlock(&Mutex);
         return LAB2_SUCCESS;
     } else {
         while(1) {
@@ -171,7 +171,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
             }
         }
     }
-   pthread_mutex_unlock(&new_node -> mutex); // lock 해제
+   pthread_mutex_unlock(&Mutex); // lock 해제
     return LAB2_SUCCESS;
 }
 
@@ -315,8 +315,8 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
  *  @return                 : status (success or fail)
  */
 int lab2_node_remove_cg(lab2_tree *tree, int key) {
-    lab2_node *temp = tree -> root;
     pthread_mutex_lock(&Mutex);
+    lab2_node *temp = tree -> root;
     lab2_node *parent = NULL , *child, *succ, *succ_p;
     while(temp -> key != key && temp != NULL) {
         parent = temp;

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -48,6 +48,7 @@ lab2_tree *lab2_tree_create() {
     // You need to implement lab2_tree_create function.
     lab2_tree *tree = (lab2_tree *) malloc(sizeof(lab2_tree));
     tree -> root = NULL;
+    pthread_mutex_init(&tree->mutex, NULL);
     return tree;
 }
 
@@ -121,17 +122,17 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
         while(1){
             if(temp -> key < new_node -> key) {
                 if(!(temp -> right)) {
-                    pthread_mutex_lock(&new_node -> mutex);
+                    pthread_mutex_lock(&(tree) -> mutex);
                     temp -> right =  new_node;
-                    pthread_mutex_unlock(&new_node -> mutex);
+                    pthread_mutex_unlock(&(tree) -> mutex);
                     break;
                 }
                 temp = temp -> right;
             }else if(temp -> key > new_node -> key) {
                 if(!(temp -> left)) {
-                    pthread_mutex_lock(&new_node -> mutex);
+                    pthread_mutex_lock(&(tree) -> mutex);
                     temp -> left = new_node;
-                    pthread_mutex_unlock(&new_node -> mutex);
+                    pthread_mutex_unlock(&(tree) -> mutex);
                     break;
                 }
                 temp = temp -> left;
@@ -259,14 +260,12 @@ int lab2_node_remove_fg(lab2_tree *tree, int key) {
         pthread_mutex_unlock(&Mutex);
     }
     
-    pthread_mutex_lock(&Mutex);
     if(temp == NULL) {
         return LAB2_SUCCESS;
     }
-    pthread_mutex_unlock(&Mutex);
     
     if((temp -> left == NULL) && (temp -> right == NULL)) { // 아래에 자식 노드가 없을 경우
-    pthread_mutex_lock(&Mutex);
+        pthread_mutex_lock(&Mutex);
         if (parent != NULL)
         {
             if(parent -> left == temp) {
@@ -406,7 +405,7 @@ void lab2_tree_delete(lab2_tree *tree) { // 트리를 초기화
  *  @return                 : status(success or fail)
  */
 void lab2_node_delete(lab2_node *node) { // 삭제한 노드의 메모리 할당 제거
-    free(node);
+    // free(node);
     node = NULL;
 }
 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -107,7 +107,30 @@ int lab2_node_insert_fg(lab2_tree *tree, lab2_node *new_node){
  *  @return                     : status (success or fail)
  */
 int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
-    // You need to implement lab2_node_insert_cg function.
+    lab2_node *temp = tree -> root;
+    if(temp == NULL) {
+        tree -> root = new_node;
+        return SUCCESS;
+    } else {
+        pthread_mutex_lock(&new_node->mutex); // lock 걸어줌
+        while(1) {
+            if(temp -> key < new_node -> key) {
+                if(!(temp -> right)) {
+                    temp -> right =  new_node;
+                    break;
+                }
+                temp = temp -> right;
+            } else if(temp -> key > new_node -> key) {
+                if(!(temp -> left)) {
+                    temp -> left = new_node;
+                    break;
+                }
+                temp = temp -> left;
+            }
+        }
+        pthread_mutex_unlock(&new_node->mutex); // lock 해제
+    }
+    return SUCCESS;
 }
 
 /* 

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -186,8 +186,14 @@ int lab2_node_remove_cg(lab2_tree *tree, int key) {
  *  @param lab2_tree *tree  : bst which you want to delete. 
  *  @return                 : status(success or fail)
  */
-void lab2_tree_delete(lab2_tree *tree) {
-    // You need to implement lab2_tree_delete function.
+void lab2_tree_delete(lab2_tree *tree) { // 트리를 초기화
+    lab2_node *temp = tree -> root;
+    if(!temp) return;
+    while(temp) {
+        int key = temp -> key;
+        lab2_node_remove(tree, key);
+        temp = tree -> root;
+    }
 }
 
 /*

--- a/lab2_bst.c
+++ b/lab2_bst.c
@@ -112,7 +112,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
         tree -> root = new_node;
         return SUCCESS;
     } else {
-        pthread_mutex_lock(&new_node->mutex); // lock 걸어줌
+        pthread_mutex_lock(&temp->mutex); // lock 걸어줌
         while(1) {
             if(temp -> key < new_node -> key) {
                 if(!(temp -> right)) {
@@ -128,7 +128,7 @@ int lab2_node_insert_cg(lab2_tree *tree, lab2_node *new_node){
                 temp = temp -> left;
             }
         }
-        pthread_mutex_unlock(&new_node->mutex); // lock 해제
+        pthread_mutex_unlock(&temp->mutex); // lock 해제
     }
     return SUCCESS;
 }


### PR DESCRIPTION
## 개요
- Fine grained lock
- Coarse grained lock
- inorder

## 상세
- 같은 key를 가진 노드가 생성될 경우 발생된 버그 fix
- 연산자 단락평가로 발생된 버그 fix
- fine locking의  segmentation 오류 fix
 
## gdb
> 디버깅은 gdb로 진행
- 멀티스레드 환경에서 delete의 locking을 제거하면 segmentation fault발생

## TestCase 100만
![스크린샷 2020-05-03 오후 10 37 57](https://user-images.githubusercontent.com/55838461/80915663-c5b3f880-8d8e-11ea-8b66-b08a541c5492.png)

